### PR TITLE
Fixing prevous uses of "finally"

### DIFF
--- a/src/starling/textures/RenderTexture.hx
+++ b/src/starling/textures/RenderTexture.hx
@@ -263,12 +263,13 @@ class RenderTexture extends SubTexture
 		}
 		catch (e:Error)
 		{
-			mDrawing = false;
-			mSupport.finishQuadBatch();
-			mSupport.nextFrame();
-			mSupport.renderTarget = null;
-			mSupport.popClipRect();
 		}
+
+		mDrawing = false;
+		mSupport.finishQuadBatch();
+		mSupport.nextFrame();
+		mSupport.renderTarget = null;
+		mSupport.popClipRect();
 	}
 	
 	/** Clears the render texture with a certain color and alpha value. Call without any
@@ -313,9 +314,10 @@ class RenderTexture extends SubTexture
 				catch (e:Error)
 				{
 					support = false;
-					if (texture != null) texture.dispose();
-					if (buffer != null) buffer.dispose();
 				}
+
+				if (texture != null) texture.dispose();
+				if (buffer != null) buffer.dispose();
 			}
 			else
 			{


### PR DESCRIPTION
It looks like a few finally blocks were subsumed into their catch blocks during the translation from AS3 to Haxe. It prevented switching the Context3D back to the back buffer after using a RenderTexture.
